### PR TITLE
Make atlas temporary owners

### DIFF
--- a/helm/keda/Chart.yaml
+++ b/helm/keda/Chart.yaml
@@ -1,5 +1,5 @@
 annotations:
-  application.giantswarm.io/team: turtles
+  application.giantswarm.io/team: atlas
   ui.giantswarm.io/logo: https://raw.githubusercontent.com/kedacore/keda/main/images/keda-logo-500x500-white.png
 apiVersion: v2
 name: keda


### PR DESCRIPTION
This PR:

- makes atlas temporary owner in the Chart.yaml so app failing alerts are sent to Atlas. This change is not reflected in the `keda-upstream` project as this is only temporary.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
