### PR TITLE
push keda to all apps collections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,3 +20,74 @@ workflows:
             branches:
               ignore:
                 - main
+      
+      - architect/push-to-app-catalog:
+          context: architect
+          executor: app-build-suite
+          name: "push to control-plane-catalog"
+          app_catalog: "control-plane-catalog"
+          app_catalog_test: "control-plane-test-catalog"
+          chart: keda
+          # Trigger job on git tag.
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - main
+      
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: capa-app-collection
+          app_name: "keda"
+          app_namespace: "giantswarm"
+          app_collection_repo: "capa-app-collection"
+          requires:
+            - "push to control-plane-catalog"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: capz-app-collection
+          app_name: "keda"
+          app_namespace: "giantswarm"
+          app_collection_repo: "capz-app-collection"
+          requires:
+            - "push to control-plane-catalog"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: cloud-director-app-collection
+          app_name: "keda"
+          app_namespace: "giantswarm"
+          app_collection_repo: "cloud-director-app-collection"
+          requires:
+            - "push to control-plane-catalog"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: vsphere-app-collection
+          app_name: "keda"
+          app_namespace: "giantswarm"
+          app_collection_repo: "vsphere-app-collection"
+          requires:
+            - "push to control-plane-catalog"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,3 +91,17 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+      
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: proxmox-app-collection
+          app_name: "keda"
+          app_namespace: "giantswarm"
+          app_collection_repo: "proxmox-app-collection"
+          requires:
+            - "push to control-plane-catalog"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Push keda to all app collections and to the control-plane-catalog.
+
 ## [3.0.0] - 2025-06-16
 
 ### Changed


### PR DESCRIPTION
This PR:

Towards https://github.com/giantswarm/giantswarm/issues/33772

As Atlas is moving to Keda to manage horizontal scaling for Loki and Mimir, we need Keda to be deployed in all MCs.

### Testing

Description on how keda-app can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for keda-app installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
