### PR TITLE
Update team annotation key to OpenContainers format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change team annotation in `Chart.yaml` to OpenContainers format (`io.giantswarm.application.team`).
+
 ## [5.0.0] - 2026-02-11
 
 ### Changed

--- a/helm/keda/Chart.yaml
+++ b/helm/keda/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=v1.23.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.19.0
+version: 5.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/keda/Chart.yaml
+++ b/helm/keda/Chart.yaml
@@ -1,15 +1,18 @@
 annotations:
-  application.giantswarm.io/team: atlas
+  io.giantswarm.application.team: atlas
   ui.giantswarm.io/logo: https://raw.githubusercontent.com/kedacore/keda/main/images/keda-logo-500x500-white.png
 apiVersion: v2
 name: keda
 description: Event-based autoscaler for workloads on Kubernetes
+
 # Specify the Kubernetes version range that we support.
 # We allow pre-release versions for cloud-specific Kubernetes versions such as  v1.21.5-gke.1302 or v1.18.9-eks-d1db3c
 kubeVersion: ">=v1.23.0-0"
+
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.0.0
+version: 2.19.0
+
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.19.0

--- a/helm/keda/templates/_helpers.tpl
+++ b/helm/keda/templates/_helpers.tpl
@@ -27,7 +27,7 @@ Generate basic labels
 {{- include "keda.crd-labels" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 giantswarm.io/service-type: managed
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 {{- if .Values.additionalLabels }}
 {{ toYaml .Values.additionalLabels }}
 {{- end }}

--- a/helm/keda/values.yaml
+++ b/helm/keda/values.yaml
@@ -875,9 +875,9 @@ certificates:
     # -- Enables Cert-manager for certificate management
     enabled: true
     # -- Certificate duration
-    duration: 8760h0m0s # 1 year
+    duration: 8760h0m0s #  1 year
     # -- Certificate renewal time before expiration
-    renewBefore: 5840h0m0s # 8 months
+    renewBefore: 5840h0m0s #  8 months
     # -- Generates a self-signed CA with Cert-manager.
     # If generateCA is false, the secret with the CA
     # has to be annotated with `cert-manager.io/allow-direct-injection: "true"`

--- a/helm/keda/values.yaml
+++ b/helm/keda/values.yaml
@@ -875,9 +875,9 @@ certificates:
     # -- Enables Cert-manager for certificate management
     enabled: true
     # -- Certificate duration
-    duration: 8760h0m0s #  1 year
+    duration: 8760h0m0s  # 1 year
     # -- Certificate renewal time before expiration
-    renewBefore: 5840h0m0s #  8 months
+    renewBefore: 5840h0m0s  # 8 months
     # -- Generates a self-signed CA with Cert-manager.
     # If generateCA is false, the secret with the CA
     # has to be annotated with `cert-manager.io/allow-direct-injection: "true"`

--- a/helm/keda/values.yaml
+++ b/helm/keda/values.yaml
@@ -875,9 +875,9 @@ certificates:
     # -- Enables Cert-manager for certificate management
     enabled: true
     # -- Certificate duration
-    duration: 8760h0m0s  # 1 year
+    duration: 8760h0m0s # 1 year
     # -- Certificate renewal time before expiration
-    renewBefore: 5840h0m0s  # 8 months
+    renewBefore: 5840h0m0s # 8 months
     # -- Generates a self-signed CA with Cert-manager.
     # If generateCA is false, the secret with the CA
     # has to be annotated with `cert-manager.io/allow-direct-injection: "true"`

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -3,7 +3,7 @@ directories:
 - contents:
   - git:
       commitTitle: Giant Swarm changes.
-      sha: dfee47bd2bb68c003a8eaf6e3d3802962071d844
+      sha: 000aebdf729c8a523ba47d73815cc40845264e8e
     path: keda
   path: helm
 kind: LockConfig


### PR DESCRIPTION
Fixes https://github.com/giantswarm/roadmap/issues/4189

Update team annotation key to OpenContainers format (io.giantswarm.application.team) in both Chart.yaml and _helpers.tpl