### PR TITLE
Change icon URL, remove logo in Chart.yaml

### DIFF
--- a/helm/keda/Chart.yaml
+++ b/helm/keda/Chart.yaml
@@ -2,7 +2,6 @@ annotations:
   io.giantswarm.application.team: atlas
   io.giantswarm.application.audience: all
   io.giantswarm.application.managed: "true"
-  ui.giantswarm.io/logo: https://raw.githubusercontent.com/kedacore/keda/main/images/keda-logo-500x500-white.png
 apiVersion: v2
 name: keda
 description: Event-based autoscaler for workloads on Kubernetes
@@ -16,7 +15,7 @@ version: 5.0.2
 # incremented each time you make changes to the application.
 appVersion: 2.19.0
 home: https://github.com/kedacore/keda
-icon: https://raw.githubusercontent.com/kedacore/keda/main/images/keda-logo-500x500-white.png
+icon: https://s.giantswarm.io/app-icons/keda/1/light.svg
 sources:
   - https://github.com/kedacore/keda
 maintainers:

--- a/helm/keda/Chart.yaml
+++ b/helm/keda/Chart.yaml
@@ -15,7 +15,7 @@ version: 5.0.2
 # incremented each time you make changes to the application.
 appVersion: 2.19.0
 home: https://github.com/kedacore/keda
-icon: https://s.giantswarm.io/app-icons/keda/1/light.svg
+icon: https://s.giantswarm.io/app-icons/keda/2/light.svg
 sources:
   - https://github.com/kedacore/keda
 maintainers:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -3,7 +3,7 @@ directories:
 - contents:
   - git:
       commitTitle: Giant Swarm changes.
-      sha: 744d5f846981b058a6f2244f379ec5a95d65fdd2
+      sha: a80aee590d451f83a88696fd236e357083cf9fb0
     path: keda
   path: helm
 kind: LockConfig


### PR DESCRIPTION
This PR

- Changes the `icon` URL to one provided by web-assets
- Removes the logo URL, as it would be only needed if it was different than the icon.
