### PR TITLE
fix: fix ABS config to not override AppVersion in Chart.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
           chart: keda
           app_catalog: giantswarm-catalog
           app_catalog_test: giantswarm-test-catalog
+          override_app_version: false
           filters:
             branches:
               ignore:
@@ -27,10 +28,10 @@ workflows:
           chart: keda
           app_catalog: control-plane-catalog
           app_catalog_test: control-plane-test-catalog
+          override_app_version: false
           filters:
             branches:
               ignore:
                 - main
             tags:
               only: /^v.*/
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix ABS config to not override AppVersion in Chart.yaml
+
 ## [5.0.3] - 2026-06-15
 
 ### Changed


### PR DESCRIPTION
In recent versions, ABS and architect orb changed the default behaviour for overriding the AppVersion in Chart.yaml when building and pushing charts. Now the default is to override it. This does not work for this chart, since we use an upstream image with a different version than the chart itself.